### PR TITLE
Add seperate GetToken function

### DIFF
--- a/auth0_test.go
+++ b/auth0_test.go
@@ -22,7 +22,7 @@ func genTestConfiguration(configuration Configuration, token string) (*JWTValida
 	return validator, req
 }
 
-func invalidProvider(req *http.Request) (interface{}, error) {
+func invalidProvider(token *jwt.JSONWebToken) (interface{}, error) {
 	return nil, errors.New("invalid secret provider")
 }
 
@@ -258,7 +258,7 @@ func TestValidateRequestAndClaims(t *testing.T) {
 
 				// claims should be unmarshalled successfully
 				claims := map[string]interface{}{}
-				err = validator.Claims(req, jwt, &claims)
+				err = validator.Claims(jwt, &claims)
 				if err != nil {
 					t.Errorf("Claims unmarshall should not have failed with error, but got: " + err.Error())
 				}
@@ -531,7 +531,7 @@ func TestValidateRequestAndClaimsWithLeeway(t *testing.T) {
 
 				// claims should be unmarshalled successfully
 				claims := map[string]interface{}{}
-				err = validator.Claims(req, jwt, &claims)
+				err = validator.Claims(jwt, &claims)
 				if err != nil {
 					t.Errorf("Claims unmarshall should not have failed with error, but got: " + err.Error())
 				}

--- a/example/go.mod
+++ b/example/go.mod
@@ -11,3 +11,5 @@ require (
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/auth0-community/go-auth0
 
 require (
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe // indirect
 	gopkg.in/square/go-jose.v2 v2.1.7
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe h1:APBCFlxGVQi3YDSHtTbNXRZhDEuz9rrnVPXZA4YbUx8=
 golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.1.7 h1:4m8fIwX7Xdw2WlFiPJtcVCDX6ELrIdpHnRmE6Uqmktk=
 gopkg.in/square/go-jose.v2 v2.1.7/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jwk_client.go
+++ b/jwk_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"gopkg.in/square/go-jose.v2/jwt"
 	"net/http"
 	"strings"
 	"sync"
@@ -112,12 +113,7 @@ func (j *JWKClient) downloadKeys() ([]jose.JSONWebKey, error) {
 }
 
 // GetSecret implements the GetSecret method of the SecretProvider interface.
-func (j *JWKClient) GetSecret(r *http.Request) (interface{}, error) {
-	token, err := j.extractor.Extract(r)
-	if err != nil {
-		return nil, err
-	}
-
+func (j *JWKClient) GetSecret(token *jwt.JSONWebToken) (interface{}, error) {
 	if len(token.Headers) < 1 {
 		return nil, ErrNoJWTHeaders
 	}


### PR DESCRIPTION
# Pull Request Report

This adds a new GetToken function, this is useful in case one wants to validate a token that was not received from a http request (such as for example in a GRPC API)

### Description

This creates a GetToken function and reworks a few interfaces to accept a jwt token instead of a http request, allowing the API to generally be used when not directly dealing with HTTP Servers (Such as, in our case, in a GRPC API)

### Type of change

- [ ] Bug fix (fix to an issue)
- [x] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

Unit tests have been adapted to the new API and are passing

**Test Configuration**

* Framework version:
* Language version:
* Browser version:

### Additional info

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
