### PR TITLE
Resolve data race in JWKClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - go get github.com/modocache/gover
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
-  - go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c
+  - go list -f '{{if len .TestGoFiles}}"go test -race -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c
 after_success:
   - gover
   - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/auth0-community/go-auth0
 require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/square/go-jose.v2 v2.1.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe h1:APBCFlxGVQi3YDSHtTbNXRZhDEuz9rrnVPXZA4YbUx8=
 golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.1.7 h1:4m8fIwX7Xdw2WlFiPJtcVCDX6ELrIdpHnRmE6Uqmktk=
 gopkg.in/square/go-jose.v2 v2.1.7/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/jwk_client_test.go
+++ b/jwk_client_test.go
@@ -141,6 +141,29 @@ func TestJWKDownloadKeyInvalid(t *testing.T) {
 	}
 }
 
+// run `go test` with `-race` for this to test for data races
+func TestJWKClientRace(t *testing.T) {
+	opts, token1, token2, err := genNewTestServer(true)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	client := NewJWKClient(opts, nil)
+
+	go func() {
+		header := token1.Headers[0]
+		_, _ = client.GetKey(header.KeyID)
+		_, _ = client.GetKey(header.KeyID)
+	}()
+
+	go func() {
+		header := token2.Headers[0]
+		_, _ = client.GetKey(header.KeyID)
+		_, _ = client.GetKey(header.KeyID)
+	}()
+}
+
 func TestGetKeyOfJWKClient(t *testing.T) {
 	opts, _, _, err := genNewTestServer(true)
 	if err != nil {


### PR DESCRIPTION
# Pull Request Report

We're using this library to authenticate GRPC requests. Noticed a few issues when trying to prime & asynchronously refresh the `JWKClient` cache. Thought it would be best to fix this in the source then trying to resolve it with locking at our end.

### Description

Changes:
- Added a test and enabled `-race` in CI build to prove existence of data race in `JWKClient`:
```
==================
WARNING: DATA RACE
Write at 0x00c00059eab0 by goroutine 102:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:202 +0x0
  github.com/auth0-community/go-auth0.(*memoryKeyCacher).Add()
      /Users/dan.dooley/Projects/auth0-go/key_cacher.go:75 +0x4c2
  github.com/auth0-community/go-auth0.(*JWKClient).GetKey()
      /Users/dan.dooley/Projects/auth0-go/jwk_client.go:75 +0x1cd
  github.com/auth0-community/go-auth0.TestJWKClientRace.func1()
      /Users/dan.dooley/Projects/auth0-go/jwk_client_test.go:156 +0xe6

Previous read at 0x00c00059eab0 by goroutine 103:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:107 +0x0
  github.com/auth0-community/go-auth0.(*memoryKeyCacher).Get()
      /Users/dan.dooley/Projects/auth0-go/key_cacher.go:56 +0xc5
  github.com/auth0-community/go-auth0.(*JWKClient).GetKey()
      /Users/dan.dooley/Projects/auth0-go/jwk_client.go:65 +0xbb
  github.com/auth0-community/go-auth0.TestJWKClientRace.func2()
      /Users/dan.dooley/Projects/auth0-go/jwk_client_test.go:162 +0xe6

Goroutine 102 (running) created at:
  github.com/auth0-community/go-auth0.TestJWKClientRace()
      /Users/dan.dooley/Projects/auth0-go/jwk_client_test.go:154 +0x31d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb

Goroutine 103 (running) created at:
  github.com/auth0-community/go-auth0.TestJWKClientRace()
      /Users/dan.dooley/Projects/auth0-go/jwk_client_test.go:160 +0x34c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
==================
```
- Resolved data race by adding an `RWMutex` lock around respective reads and writes to the `KeyCacher`
- Existing mutex was allowing only a single call to `downloadKeys` at a time. Multiple missing keys will queue up on this lock. Replaced this mutex with `singleflight` ([godoc](https://godoc.org/golang.org/x/sync/singleflight)) so all requests can wait on the same call to `downloadKeys`.

### Type of change

- [x] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

Running the test in the first commit with the `-race` flag indicates that a race is caused inside the `KeyCacher`
The same test with `-race` no longer detects a race after the fix commit.

Couldn't think of a reasonable test for the `singleflight` change without significantly reworking some of the test helpers. Let me know if you want me to try a bit harder with this.

**Test Configuration**

* Framework version: N/A
* Language version: Go 1.14.4
* Browser version: N/A

### Additional info

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation _(not sure if any are needed as there should be no change in behaviour)_
- [x] My changes generate no new warnings and errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
